### PR TITLE
Allow control of limelight leds while disabled

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -62,7 +62,7 @@ public class Robot extends TimedRobot {
 
   @Override
   public void disabledPeriodic() {
-    m_robotContainer.m_sensors.limelight.ledOff();
+    m_robotContainer.m_sensors.ledOff();
   }
 
   /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -106,7 +106,7 @@ public class RobotContainer {
   *                                                                                                                      
   */
 
-  public final Sensors m_sensors = new Sensors();
+  public final Sensors m_sensors = new Sensors(m_driverController::isButtonAPressed);
   private final Drive m_drive = new Drive(m_sensors);
   private final Climber m_climber = new Climber();
   private final Arm m_arm = new Arm(m_driverController::isButtonStartPressed);

--- a/src/main/java/frc/robot/commands/vision/LimelightToggle.java
+++ b/src/main/java/frc/robot/commands/vision/LimelightToggle.java
@@ -27,9 +27,9 @@ public class LimelightToggle extends InstantCommand {
   @Override
   public void initialize() {
     if(toggle) {
-      sensors.limelight.ledOn();
+      sensors.ledOn();
     } else {
-      sensors.limelight.ledOff();
+      sensors.ledOff();
     }
   }
 }

--- a/src/main/java/frc/robot/subsystems/Sensors.java
+++ b/src/main/java/frc/robot/subsystems/Sensors.java
@@ -7,6 +7,8 @@
 
 package frc.robot.subsystems;
 
+import java.util.function.BooleanSupplier;
+
 import edu.wpi.cscore.UsbCamera;
 import edu.wpi.cscore.VideoSink;
 import edu.wpi.first.cameraserver.CameraServer;
@@ -25,7 +27,9 @@ import frc.robot.util.Limelight;
 
 public class Sensors extends SubsystemBase {
   public final NavX navx;
-  public final Limelight limelight;
+  
+  private final Limelight limelight;
+  private BooleanSupplier ledOverride;
 
   UsbCamera frontCamera = CameraServer.getInstance().startAutomaticCapture(0);
   UsbCamera rearCamera = CameraServer.getInstance().startAutomaticCapture(1);
@@ -34,7 +38,9 @@ public class Sensors extends SubsystemBase {
   /**
    * Creates a new Sensors subsystem
    */
-  public Sensors() {
+  public Sensors(BooleanSupplier ledOverride) {
+    this.ledOverride = ledOverride;
+
     navx = new NavX();
     navx.zeroYaw();
 
@@ -53,6 +59,16 @@ public class Sensors extends SubsystemBase {
 
   public void setToRearCamera() {
     server.setSource(rearCamera);
+  }
+
+  public void ledOn() {
+    limelight.ledOn();
+  }
+
+  public void ledOff() {
+    if(!ledOverride.getAsBoolean()) {
+      limelight.ledOff();
+    }
   }
 
   public double getDistanceToTarget() {
@@ -82,5 +98,10 @@ public class Sensors extends SubsystemBase {
     SmartDashboard.putBoolean("Limelight has target?", limelight.hasTarget());
     SmartDashboard.putNumber("Distance to target", getDistanceToTarget());
     SmartDashboard.putNumber("Angle to target", limelight.getTargetHorizontalOffsetAngle());
+
+    // Check LED override
+    if(ledOverride.getAsBoolean()) {
+      limelight.ledOn();
+    }
   }
 }

--- a/src/main/java/frc/robot/subsystems/Sensors.java
+++ b/src/main/java/frc/robot/subsystems/Sensors.java
@@ -12,6 +12,7 @@ import java.util.function.BooleanSupplier;
 import edu.wpi.cscore.UsbCamera;
 import edu.wpi.cscore.VideoSink;
 import edu.wpi.first.cameraserver.CameraServer;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
@@ -66,7 +67,7 @@ public class Sensors extends SubsystemBase {
   }
 
   public void ledOff() {
-    if(!ledOverride.getAsBoolean()) {
+    if(!(DriverStation.getInstance().isDisabled() && ledOverride.getAsBoolean())) {
       limelight.ledOff();
     }
   }
@@ -99,8 +100,8 @@ public class Sensors extends SubsystemBase {
     SmartDashboard.putNumber("Distance to target", getDistanceToTarget());
     SmartDashboard.putNumber("Angle to target", limelight.getTargetHorizontalOffsetAngle());
 
-    // Check LED override
-    if(ledOverride.getAsBoolean()) {
+    // Check LED override, only when disabled
+    if(DriverStation.getInstance().isDisabled() && ledOverride.getAsBoolean()) {
       limelight.ledOn();
     }
   }


### PR DESCRIPTION
This change allows the limelight leds to be turned on and off while disabled using the driver controller A button. This feature is important for field calibration, where the robot is not allowed to be enabled.